### PR TITLE
fix Hackerspace.Gent phrasing

### DIFF
--- a/4-the-board.md
+++ b/4-the-board.md
@@ -13,10 +13,10 @@ Both jobs are critically important to the space. Many hackerspaces disbanded bec
 
 ## Why is there a board?
 
-There are two reasons why Hackerspace Ghent has a board:
+There are two reasons why Hackerspace.Gent has a board:
 
 - A Belgian non-profit organization (VZW) requires a board which is legally liable in case something goes wrong. In the past, we had a board on paper, but the space was completely run by consensus. This caused a bunch of issues since the board was legally liable, but it didn't actually have any power to prevent bad things from happening.
-- People don't like conflict and confrontation. If nobody speaks up and nobody actively tries to resolve conflicts, people just ignore it until it explodes, taking down half the space with it. Hackerspace Ghent almost disbanded after such an explosion and we vowed to never have it again. Thus, the board is responsible for speaking up and fixing conflicts, even if that is really uncomfortable.
+- People don't like conflict and confrontation. If nobody speaks up and nobody actively tries to resolve conflicts, people just ignore it until it explodes, taking down half the space with it. Hackerspace.Gent almost disbanded after such an explosion and we vowed to never have it again. Thus, the board is responsible for speaking up and fixing conflicts, even if that is really uncomfortable.
 
 ## What power does the board have?
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ We are a breeding ground for awesome ideas. We provide a nest where those ideas 
 
 ## We failed, but we try again
 
-We created our very own Ghent hackerspace. We had two rules: be excellent to each other and decide everything by consensus. We thought normal human interaction and common sense would solve all problems. Sadly, this was not true. When our hackerspace almost died, we decided to "Hack the Hackerspace". We found that the problems could all be traced to the following root causes:
+We created our very own hackerspace in Ghent. We had two rules: be excellent to each other and decide everything by consensus. We thought normal human interaction and common sense would solve all problems. Sadly, this was not true. When our hackerspace almost died, we decided to "Hack the Hackerspace". We found that the problems could all be traced to the following root causes:
 
 * We cannot rely on common sense because **people have different realities.**
 * **People have different, conflicting goals.** Because of that, consensus will never be reached on certain things. Problems will arise and they will not be solved. In most cases, no solution is worse than a bad solution.
 
 We knew that, in order to fix this, we needed a system that gets the best out of everyone and enables us to be awesome! After long late-night discussions, we came up with "the hackerspace blueprint", a document that describes how to run a hackerspace in a way that brings out the best in people. **To get the latest PDF version of this document, go [here](https://github.com/0x20/hackerspace-blueprint/releases/latest) and download the file `hackerspace-blueprint.pdf`.**
 
-We have been refining this system for a few years now, tweaking the system when we encounter issues and explaining important parts in more details. This document specifically describes how Hackerspace Gent runs, but it is generic enough so that it can be easily adapted to other hackerspaces and similar organizations. Feel free to use and remix this for your own benefit, learn from our mistakes and let us know what you think of it!
+We have been refining this system for a few years now, tweaking the system when we encounter issues and explaining important parts in more details. This document specifically describes how Hackerspace.Gent runs, but it is generic enough so that it can be easily adapted to other hackerspaces and similar organizations. Feel free to use and remix this for your own benefit, learn from our mistakes and let us know what you think of it!
 
 The goal of this system is to empower people to get the best out of themselves. It stimulates collaboration and enables people to think and solve problems creatively. We know that this system will be flawed from the start. We know that control of people is evil. But a flawed system is better than no system, and we continuously update this system to make it better. That is why [this is on GitHub](https://github.com/0x20/hackerspace-blueprint), in order to make it easy to build on the hackerspace blueprint as a community.
 


### PR DESCRIPTION
fix the occurences of "hackerspace ghent"
preserved the exact phrasing of our legal name as "Hackerspace Gent"
and kept "Ghent" where it's referring to the city's name.