### PR TITLE
Announce membership applications on the Changelog

### DIFF
--- a/5-membership.md
+++ b/5-membership.md
@@ -3,16 +3,18 @@
 ## How do I become a member?
 
 1. Fill in [the membership application form](https://wiki.hackerspace.gent/Membership_form) and get two people to sign as sponsors. They will be responsible for making sure you get settled nicely, that you understand how the hackerspace works, and know how you can participate.
-2. Attend a meeting and present your application. On this meeting you announce you want to become a member and who your sponsors are. If you want you can talk a bit about why you're interested in the space. *Note: this meeting is simply an announcement. Your membership won't be discussed further, and no decision about it will be made on that meeting.*
-3. On the next meeting, your membership will be decided upon. It's useful to have you present at that meeting, but this is not a requirement. As a bonus for coming to the meeting, membership is often the first thing to be decided on a meeting. When you get voted in, you can join the rest of the meeting as a member! Membership decisions at a meeting follow the same process as other meeting decisions. See Chapter 3 for more info.
-4. Create an automatic bank transfer to transfer the membership fee each month. You will get your key after you made your first payment.
+2. Announce your membership application on the Changelog. Include in the message who your sponsors are.
+3. Attend a meeting and present your application. On this meeting you announce you want to become a member and who your sponsors are. If you want you can talk a bit about why you're interested in the space. *Note: we won't discuss your membership further on this meeting and will not make any decision about it.*
+4. On the next meeting, your membership will be decided upon. It's useful to have you present at that meeting, but this is not a requirement. As a bonus for coming to the meeting, membership is often the first thing to be decided on a meeting. When you get voted in, you can join the rest of the meeting as a member! Membership decisions at a meeting follow the same process as other meeting decisions. See Chapter 3 for more info.
+5. Create an automatic bank transfer to transfer the membership fee each month. You will get your key after you made your first payment.
 
 Why this process?
 
 * Step #1 ensures that two people know and trust the applicant enough to vouch for them. It als ensures that the "culture" of the space gets transferred to new members.
-* Step #2 ensures that the applicant understands how meetings are run and that there is some time between the applicant first arriving in the space and the applicant being voted in.
-* Step #3 ensures that there is enough support for the applicant. The meeting decision model is used for the same reasons as to why it's used for meetings: a bad solution is better than no solution.
-* Step #4 gives the new member an incentive to pay asap.
+* Step #2 ensures everyone knows you want to become a member.
+* Step #3 ensures that the applicant understands how meetings are run and that there is some time between the applicant first arriving in the space and the applicant being voted in.
+* Step #4 ensures that there is enough support for the applicant. The meeting decision model is used for the same reasons as to why it's used for meetings: a bad solution is better than no solution.
+* Step #5 gives the new member an incentive to pay asap.
 
 *Note: If you want more context, see the `HTH_2018-11-17_membership.md` document in "the legacy" for more discussion on the membership procedure.*
 

--- a/5-membership.md
+++ b/5-membership.md
@@ -5,7 +5,7 @@
 1. Fill in [the membership application form](https://wiki.hackerspace.gent/Membership_form) and get two people to sign as sponsors. They will be responsible for making sure you get settled nicely, that you understand how the hackerspace works, and know how you can participate.
 2. Announce your membership application on the Changelog. Include in the message who your sponsors are.
 3. Attend a meeting and present your application. On this meeting you announce you want to become a member and who your sponsors are. If you want, you can talk a bit about why you're interested in the space. *Note: we won't discuss your membership further on this meeting and will not make any decision about it.*
-4. On the next meeting, your membership will be decided upon. It's useful to have you present at that meeting, but this is not a requirement. As a bonus for coming to the meeting, membership is often the first thing to be decided on a meeting. When you get voted in, you can join the rest of the meeting as a member! Membership decisions at a meeting follow the same process as other meeting decisions. See Chapter 3 for more info.
+4. On a next meeting, your membership will be decided upon. It's useful to have you present at that meeting, but this is not a requirement. As a bonus for coming to the meeting, membership is often the first thing to be decided on a meeting. When you get voted in, you can join the rest of the meeting as a member! Membership decisions at a meeting follow the same process as other meeting decisions. See Chapter 3 for more info.
 5. Create an automatic bank transfer to transfer the membership fee each month. You will get your key after you made your first payment.
 
 Why this process?

--- a/5-membership.md
+++ b/5-membership.md
@@ -4,7 +4,7 @@
 
 1. Fill in [the membership application form](https://wiki.hackerspace.gent/Membership_form) and get two people to sign as sponsors. They will be responsible for making sure you get settled nicely, that you understand how the hackerspace works, and know how you can participate.
 2. Announce your membership application on the Changelog. Include in the message who your sponsors are.
-3. Attend a meeting and present your application. On this meeting you announce you want to become a member and who your sponsors are. If you want you can talk a bit about why you're interested in the space. *Note: we won't discuss your membership further on this meeting and will not make any decision about it.*
+3. Attend a meeting and present your application. On this meeting you announce you want to become a member and who your sponsors are. If you want, you can talk a bit about why you're interested in the space. *Note: we won't discuss your membership further on this meeting and will not make any decision about it.*
 4. On the next meeting, your membership will be decided upon. It's useful to have you present at that meeting, but this is not a requirement. As a bonus for coming to the meeting, membership is often the first thing to be decided on a meeting. When you get voted in, you can join the rest of the meeting as a member! Membership decisions at a meeting follow the same process as other meeting decisions. See Chapter 3 for more info.
 5. Create an automatic bank transfer to transfer the membership fee each month. You will get your key after you made your first payment.
 


### PR DESCRIPTION
Given not all members always read the meeting minutes, it's best to explicitly ask prospective members to announce their application on the Changelog. This way, everyone who keeps somewhat up-to-date with space matters will see who wants to become a member.

This PR also attempts to further clarify the existing steps.